### PR TITLE
Parse interpolated strings

### DIFF
--- a/lib/code_breaker/parsable/data_types.rb
+++ b/lib/code_breaker/parsable/data_types.rb
@@ -29,6 +29,19 @@ module CodeBreaker
           { node.type => parse_children(node).first }
         end
 
+        # interpolated string
+        def parse_dstr_node(node)
+          values = parse_as_hash(node)[node.type].map do |value|
+            if value.kind_of?(Array)
+              value.flatten(1)
+            else
+              value
+            end
+          end
+
+          { node.type => values }
+        end
+
         def parse_sym_node(node)
           Symbol
         end

--- a/spec/code_breaker/parser/data_types_spec.rb
+++ b/spec/code_breaker/parser/data_types_spec.rb
@@ -43,10 +43,18 @@ describe CodeBreaker::Parser do
       end
     end
 
-    context 'for a root node representing a interpolated executed string' do
+    context 'for a root node representing an interpolated executed string' do
       it 'returns a Hash with key :xstr and value String' do
         input = "%x{string}"
         output = { xstr: String }
+        expect(input).to be_parsed_as output
+      end
+    end
+
+    context 'for a root node representing an interpolated string' do
+      it 'returns a Hash with key :dstr and an Array of interpolation values' do
+        input = '"#{1 + 2} interpolated string #{\'here\'}"'
+        output = { dstr: [[Fixnum, :+, Fixnum], String, [String]] }
         expect(input).to be_parsed_as output
       end
     end


### PR DESCRIPTION
Implemented node types: `dstr`
Fixes #4.
