### PR TITLE
Feature/drop activesupport dependency

### DIFF
--- a/code_breaker.gemspec
+++ b/code_breaker.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'parser',        '~> 2.2'
+  spec.add_dependency 'parser', '~> 2.3'
 
   spec.add_development_dependency 'bundler', '~> 1.10'
   spec.add_development_dependency 'rake',    '~> 10.0'

--- a/code_breaker.gemspec
+++ b/code_breaker.gemspec
@@ -28,7 +28,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'parser',        '~> 2.2'
-  spec.add_dependency 'activesupport', '~> 4'
 
   spec.add_development_dependency 'bundler', '~> 1.10'
   spec.add_development_dependency 'rake',    '~> 10.0'

--- a/lib/code_breaker/parsable/assignments.rb
+++ b/lib/code_breaker/parsable/assignments.rb
@@ -1,63 +1,58 @@
-require 'active_support/concern'
-
 module CodeBreaker
   module Parsable
     module Assignments
-      extend ActiveSupport::Concern
       include Parsable::Node
 
-      included do
-        # local variable assignment
-        alias_method :parse_lvasgn_node, :parse_as_hash
+      # local variable assignment
+      alias_method :parse_lvasgn_node, :parse_as_hash
 
-        # instance variable assignment
-        alias_method :parse_ivasgn_node, :parse_as_hash
+      # instance variable assignment
+      alias_method :parse_ivasgn_node, :parse_as_hash
 
-        # class variable assignment
-        alias_method :parse_cvasgn_node, :parse_as_hash
+      # class variable assignment
+      alias_method :parse_cvasgn_node, :parse_as_hash
 
-        # global variable assignment
-        alias_method :parse_gvasgn_node, :parse_as_hash
+      # global variable assignment
+      alias_method :parse_gvasgn_node, :parse_as_hash
 
-        # operation assignment
-        alias_method :parse_op_asgn_node, :parse_as_hash
+      # operation assignment
+      alias_method :parse_op_asgn_node, :parse_as_hash
 
-        # or assignment
-        alias_method :parse_or_asgn_node, :parse_as_hash
+      # or assignment
+      alias_method :parse_or_asgn_node, :parse_as_hash
 
-        # and assignment
-        alias_method :parse_and_asgn_node, :parse_as_hash
+      # and assignment
+      alias_method :parse_and_asgn_node, :parse_as_hash
 
-        # multiple assignment
-        def parse_masgn_node(node)
-          lhs, rhs = parse_children(node)
-          values   = multiple_assignment_values(lhs, rhs)
+      # multiple assignment
+      def parse_masgn_node(node)
+        lhs, rhs = parse_children(node)
+        values   = multiple_assignment_values(lhs, rhs)
 
-          { node.type => { lhs => values } }
-        end
+        { node.type => { lhs => values } }
+      end
 
-        # multiple left hand side
-        def parse_mlhs_node(node)
-          parse_children(node).map(&:values).flatten
-        end
+      # multiple left hand side
+      def parse_mlhs_node(node)
+        parse_children(node).map(&:values).flatten
+      end
 
-        # constant assignment
-        def parse_casgn_node(node)
-          name     = node.children[1]
-          children = node.children[2]
-          value    = children.nil? ? name : [name, parse(node.children[2])]
+      # constant assignment
+      def parse_casgn_node(node)
+        name     = node.children[1]
+        children = node.children[2]
+        value    = children.nil? ? name : [name, parse(node.children[2])]
 
-          { node.type => value }
-        end
+        { node.type => value }
+      end
 
-        private
+      private
 
-        def multiple_assignment_values(lhs, rhs)
-          if rhs.is_a?(Hash) && rhs.key?(:array)
-            rhs[:array]
-          else
-            [rhs] + (1...lhs.count).map { NilClass }
-          end
+      def multiple_assignment_values(lhs, rhs)
+        if rhs.is_a?(Hash) && rhs.key?(:array)
+          rhs[:array]
+        else
+          [rhs] + (1...lhs.count).map { NilClass }
         end
       end
     end

--- a/lib/code_breaker/parsable/data_types.rb
+++ b/lib/code_breaker/parsable/data_types.rb
@@ -1,69 +1,64 @@
-require 'active_support/concern'
-
 module CodeBreaker
   module Parsable
     module DataTypes
-      extend ActiveSupport::Concern
       include Parsable::Node
 
-      included do
-        def parse_nil_node(node)
-          NilClass
-        end
-
-        def parse_true_node(node)
-          TrueClass
-        end
-
-        def parse_false_node(node)
-          FalseClass
-        end
-
-        def parse_str_node(node)
-          String
-        end
-
-        # interpolated executed string
-        def parse_xstr_node(node)
-          { node.type => parse_children(node).first }
-        end
-
-        # interpolated string
-        def parse_dstr_node(node)
-          values = parse_as_hash(node)[node.type].map do |value|
-            if value.is_a?(Array)
-              value.flatten(1)
-            else
-              value
-            end
-          end
-
-          { node.type => values }
-        end
-
-        def parse_sym_node(node)
-          Symbol
-        end
-
-        def parse_float_node(node)
-          Float
-        end
-
-        def parse_regexp_node(node)
-          Regexp
-        end
-
-        def parse_int_node(node)
-          node.children[0].class
-        end
-
-        def parse_pair_node(node)
-          { parse(node.children[0]) => parse(node.children[1]) }
-        end
-
-        alias_method :parse_hash_node,  :parse_as_hash
-        alias_method :parse_array_node, :parse_as_hash
+      def parse_nil_node(node)
+        NilClass
       end
+
+      def parse_true_node(node)
+        TrueClass
+      end
+
+      def parse_false_node(node)
+        FalseClass
+      end
+
+      def parse_str_node(node)
+        String
+      end
+
+      # interpolated executed string
+      def parse_xstr_node(node)
+        { node.type => parse_children(node).first }
+      end
+
+      # interpolated string
+      def parse_dstr_node(node)
+        values = parse_as_hash(node)[node.type].map do |value|
+          if value.is_a?(Array)
+            value.flatten(1)
+          else
+            value
+          end
+        end
+
+        { node.type => values }
+      end
+
+      def parse_sym_node(node)
+        Symbol
+      end
+
+      def parse_float_node(node)
+        Float
+      end
+
+      def parse_regexp_node(node)
+        Regexp
+      end
+
+      def parse_int_node(node)
+        node.children[0].class
+      end
+
+      def parse_pair_node(node)
+        { parse(node.children[0]) => parse(node.children[1]) }
+      end
+
+      alias_method :parse_hash_node,  :parse_as_hash
+      alias_method :parse_array_node, :parse_as_hash
     end
   end
 end

--- a/lib/code_breaker/parsable/keywords.rb
+++ b/lib/code_breaker/parsable/keywords.rb
@@ -1,99 +1,94 @@
-require 'active_support/concern'
-
 module CodeBreaker
   module Parsable
     module Keywords
-      extend ActiveSupport::Concern
       include Parsable::Node
 
-      included do
-        alias_method :parse_or_node,      :parse_as_hash
-        alias_method :parse_and_node,     :parse_as_hash
-        alias_method :parse_def_node,     :parse_as_hash
-        alias_method :parse_yield_node,   :parse_as_hash
-        alias_method :parse_rescue_node,  :parse_as_hash
-        alias_method :parse_resbody_node, :parse_as_hash
+      alias_method :parse_or_node,      :parse_as_hash
+      alias_method :parse_and_node,     :parse_as_hash
+      alias_method :parse_def_node,     :parse_as_hash
+      alias_method :parse_yield_node,   :parse_as_hash
+      alias_method :parse_rescue_node,  :parse_as_hash
+      alias_method :parse_resbody_node, :parse_as_hash
 
-        alias_method :parse_break_node,   :parse_as_node_type
-        alias_method :parse_next_node,    :parse_as_node_type
-        alias_method :parse_retry_node,   :parse_as_node_type
-        alias_method :parse_self_node,    :parse_as_node_type
+      alias_method :parse_break_node,   :parse_as_node_type
+      alias_method :parse_next_node,    :parse_as_node_type
+      alias_method :parse_retry_node,   :parse_as_node_type
+      alias_method :parse_self_node,    :parse_as_node_type
 
-        def parse_loop_node(node)
-          condition = node.children[0]
-          body      = node.children[1]
+      def parse_loop_node(node)
+        condition = node.children[0]
+        body      = node.children[1]
 
-          { node.type => parse(condition), do: parse(body) }
+        { node.type => parse(condition), do: parse(body) }
+      end
+
+      alias_method :parse_while_node, :parse_loop_node
+      alias_method :parse_until_node, :parse_loop_node
+
+      def parse_for_node(node)
+        variable  = node.children[0]
+        range     = node.children[1]
+        body      = node.children[2]
+
+        { node.type => parse(variable), in: parse(range), do: parse(body) }
+      end
+
+      def parse_if_node(node)
+        condition = node.children[0]
+        if_body   = node.children[1]
+        else_body = node.children[2]
+
+        clause = { node.type => parse(condition), then: parse(if_body) }
+        clause[:else] = parse(else_body) if else_body
+
+        clause
+      end
+
+      def parse_module_node(node)
+        name  = parse(node.children[0])
+        body  = node.children[1].nil? ? nil : parse(node.children[1])
+        value = body ? [name, body] : [name]
+
+        { node.type => value }
+      end
+
+      def parse_return_node(node)
+        children = parse_children(node)
+        values   = children.length == 1 ? children[0] : children
+
+        { node.type => values }
+      end
+
+      def parse_kwbegin_node(node)
+        rescue_given = node.children.first.type == :rescue
+
+        if rescue_given
+          rescue_part = parse(node.children.first)[:rescue]
+
+          {
+            begin: rescue_part.first,
+            rescue: rescue_part.last[:resbody].first
+          }
+        else
+          { begin: parse(node.children.last) }
         end
+      end
 
-        alias_method :parse_while_node, :parse_loop_node
-        alias_method :parse_until_node, :parse_loop_node
+      def parse_case_node(node)
+        case_part  = parse(node.children.first)
+        when_parts = node.children[1...-1].map { |child| parse(child) }
+        else_part  = parse(node.children.last)
 
-        def parse_for_node(node)
-          variable  = node.children[0]
-          range     = node.children[1]
-          body      = node.children[2]
+        statement = { case: when_parts.unshift(case_part) }
+        statement[:case] << { else: else_part } if else_part
+        statement
+      end
 
-          { node.type => parse(variable), in: parse(range), do: parse(body) }
-        end
+      def parse_when_node(node)
+        when_part = parse(node.children[0])
+        then_part = parse(node.children[1])
 
-        def parse_if_node(node)
-          condition = node.children[0]
-          if_body   = node.children[1]
-          else_body = node.children[2]
-
-          clause = { node.type => parse(condition), then: parse(if_body) }
-          clause[:else] = parse(else_body) if else_body
-
-          clause
-        end
-
-        def parse_module_node(node)
-          name  = parse(node.children[0])
-          body  = node.children[1].nil? ? nil : parse(node.children[1])
-          value = body ? [name, body] : [name]
-
-          { node.type => value }
-        end
-
-        def parse_return_node(node)
-          children = parse_children(node)
-          values   = children.length == 1 ? children[0] : children
-
-          { node.type => values }
-        end
-
-        def parse_kwbegin_node(node)
-          rescue_given = node.children.first.type == :rescue
-
-          if rescue_given
-            rescue_part = parse(node.children.first)[:rescue]
-
-            {
-              begin: rescue_part.first,
-              rescue: rescue_part.last[:resbody].first
-            }
-          else
-            { begin: parse(node.children.last) }
-          end
-        end
-
-        def parse_case_node(node)
-          case_part  = parse(node.children.first)
-          when_parts = node.children[1...-1].map { |child| parse(child) }
-          else_part  = parse(node.children.last)
-
-          statement = { case: when_parts.unshift(case_part) }
-          statement[:case] << { else: else_part } if else_part
-          statement
-        end
-
-        def parse_when_node(node)
-          when_part = parse(node.children[0])
-          then_part = parse(node.children[1])
-
-          { when: when_part, then: then_part }
-        end
+        { when: when_part, then: then_part }
       end
     end
   end

--- a/lib/code_breaker/parsable/language_elements.rb
+++ b/lib/code_breaker/parsable/language_elements.rb
@@ -1,40 +1,35 @@
-require 'active_support/concern'
-
 module CodeBreaker
   module Parsable
     module LanguageElements
-      extend ActiveSupport::Concern
       include Parsable::Node
 
-      included do
-        alias_method :parse_block_node,    :parse_as_hash
-        alias_method :parse_args_node,     :parse_as_hash
-        alias_method :parse_arg_node,      :parse_as_last_child_hash
-        alias_method :parse_blockarg_node, :parse_as_last_child_hash
-        alias_method :parse_restarg_node,  :parse_as_last_child_hash
+      alias_method :parse_block_node,    :parse_as_hash
+      alias_method :parse_args_node,     :parse_as_hash
+      alias_method :parse_arg_node,      :parse_as_last_child_hash
+      alias_method :parse_blockarg_node, :parse_as_last_child_hash
+      alias_method :parse_restarg_node,  :parse_as_last_child_hash
 
-        # optional argument
-        alias_method :parse_optarg_node, :parse_as_hash
+      # optional argument
+      alias_method :parse_optarg_node, :parse_as_hash
 
-        # keyword argument
-        alias_method :parse_kwarg_node, :parse_as_last_child_hash
+      # keyword argument
+      alias_method :parse_kwarg_node, :parse_as_last_child_hash
 
-        # optional keyword argument
-        alias_method :parse_kwoptarg_node, :parse_as_hash
+      # optional keyword argument
+      alias_method :parse_kwoptarg_node, :parse_as_hash
 
-        # keyword rest argument
-        alias_method :parse_kwrestarg_node, :parse_as_last_child_hash
+      # keyword rest argument
+      alias_method :parse_kwrestarg_node, :parse_as_last_child_hash
 
-        def parse_block_pass_node(node)
-          { node.type => node.children.first.children.last }
-        end
+      def parse_block_pass_node(node)
+        { node.type => node.children.first.children.last }
+      end
 
-        def parse_splat_node(node)
-          children = parse_children(node).flatten(1)
-          values   = children.length == 1 ? children[0] : children
+      def parse_splat_node(node)
+        children = parse_children(node).flatten(1)
+        values   = children.length == 1 ? children[0] : children
 
-          { node.type => values }
-        end
+        { node.type => values }
       end
     end
   end

--- a/lib/code_breaker/parsable/ranges.rb
+++ b/lib/code_breaker/parsable/ranges.rb
@@ -1,18 +1,13 @@
-require 'active_support/concern'
-
 module CodeBreaker
   module Parsable
     module Ranges
-      extend ActiveSupport::Concern
       include Parsable::Node
 
-      included do
-        # inclusive range a..b
-        alias_method :parse_irange_node, :parse_as_hash
+      # inclusive range a..b
+      alias_method :parse_irange_node, :parse_as_hash
 
-        # exclusive range a...b
-        alias_method :parse_erange_node, :parse_as_hash
-      end
+      # exclusive range a...b
+      alias_method :parse_erange_node, :parse_as_hash
     end
   end
 end

--- a/lib/code_breaker/parsable/variable_types.rb
+++ b/lib/code_breaker/parsable/variable_types.rb
@@ -1,26 +1,21 @@
-require 'active_support/concern'
-
 module CodeBreaker
   module Parsable
     module VariableTypes
-      extend ActiveSupport::Concern
       include Parsable::Node
 
-      included do
-        alias_method :parse_const_node, :parse_as_last_child_hash
+      alias_method :parse_const_node, :parse_as_last_child_hash
 
-        # local variable
-        alias_method :parse_lvar_node, :parse_as_last_child_hash
+      # local variable
+      alias_method :parse_lvar_node, :parse_as_last_child_hash
 
-        # instance variable
-        alias_method :parse_ivar_node, :parse_as_last_child_hash
+      # instance variable
+      alias_method :parse_ivar_node, :parse_as_last_child_hash
 
-        # class variable
-        alias_method :parse_cvar_node, :parse_as_last_child_hash
+      # class variable
+      alias_method :parse_cvar_node, :parse_as_last_child_hash
 
-        # global variable
-        alias_method :parse_gvar_node, :parse_as_last_child_hash
-      end
+      # global variable
+      alias_method :parse_gvar_node, :parse_as_last_child_hash
     end
   end
 end

--- a/lib/code_breaker/parsable/wrappers.rb
+++ b/lib/code_breaker/parsable/wrappers.rb
@@ -1,22 +1,17 @@
-require 'active_support/concern'
-
 module CodeBreaker
   module Parsable
     module Wrappers
-      extend ActiveSupport::Concern
       include Parsable::Node
 
-      included do
-        def parse_send_node(node)
-          if [:Rational, :Complex].include?(node.children[1])
-            return node.children[1].to_s.constantize
-          end
-
-          parse_children(node).flatten(1)
+      def parse_send_node(node)
+        if [:Rational, :Complex].include?(node.children[1])
+          return Kernel.const_get(node.children[1].to_s)
         end
 
-        alias_method :parse_begin_node, :parse_children
+        parse_children(node).flatten(1)
       end
+
+      alias_method :parse_begin_node, :parse_children
     end
   end
 end

--- a/lib/code_breaker/parser.rb
+++ b/lib/code_breaker/parser.rb
@@ -1,6 +1,5 @@
 require 'code_breaker/parsable'
 require 'parser/current'
-require 'active_support/inflector'
 
 module CodeBreaker
   class Parser


### PR DESCRIPTION
Because we used ActiveSupport only for one `constantize` and for concerns (`included do ...`), which can be done with a plain `include`, we drop ActiveSupport as a dependency.

Also updates the required parser version to ~> 2.3. 
