### PR TITLE
Use Integer instead of Fixnum and Bignum

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,10 @@
 language: ruby
 rvm:
   - 2.2.0
-before_install: gem install bundler -v 1.10.6
+  - 2.2.7
+  - 2.3.0
+  - 2.3.4
+  - 2.4.0
+  - 2.4.1
+  - ruby-head
+before_install: gem install bundler -v 1.14.6

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ sum = Rational(2, 3) + 4
 ```
 
 By breaking down this line into the receiver classes and called methods you can
-check e.g. whether a code snippet assigns the sum of a Rational and a Fixnum to
+check e.g. whether a code snippet assigns the sum of a Rational and an Integer to
 a variable with the name `sum`.
 
 Testing global code snippets might be important for testing the code of simple
@@ -44,7 +44,11 @@ require 'code_breaker'
 
 code_snippet = 'crazy_number = Rational(3, 5) + 42 - Complex(2.3, 6.4) * 1.2'
 CodeBreaker.parse(code_snippet)
+# for Ruby < v2.4.0:
 # => {:lvasgn=>[:crazy_number, [Rational, :+, Fixnum, :-, Complex, :*, Float]]}
+#
+# for Ruby >= v2.4.0:
+# => {:lvasgn=>[:crazy_number, [Rational, :+, Integer, :-, Complex, :*, Float]]}
 
 code_snippet = '"hello" + "World"'
 CodeBreaker.parse(code_snippet)
@@ -84,4 +88,3 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/daigak
 ## License
 
 The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).
-

--- a/spec/code_breaker/parser/assignments_spec.rb
+++ b/spec/code_breaker/parser/assignments_spec.rb
@@ -5,7 +5,7 @@ describe CodeBreaker::Parser do
     context 'for a local variable assignment' do
       it 'returns a Hash with key :lvasgn' do
         input  = "name = 'John Doe' + 24.to_s"
-        output = { lvasgn: [:name, [String, :+, Fixnum, :to_s]] }
+        output = { lvasgn: [:name, [String, :+, fixnum_or_integer, :to_s]] }
         expect(input).to be_parsed_as output
       end
     end
@@ -13,7 +13,7 @@ describe CodeBreaker::Parser do
     context 'for an instance variable assignment' do
       it 'returns a Hash with key :ivasgn' do
         input  = "@name = 'John Doe' + 24.to_s"
-        output = { ivasgn: [:@name, [String, :+, Fixnum, :to_s]] }
+        output = { ivasgn: [:@name, [String, :+, fixnum_or_integer, :to_s]] }
         expect(input).to be_parsed_as output
       end
     end
@@ -21,7 +21,7 @@ describe CodeBreaker::Parser do
     context 'for a class variable assignment' do
       it 'returns a Hash with key :cvasgn' do
         input  = "@@name = 'John Doe' + 24.to_s"
-        output = { cvasgn: [:@@name, [String, :+, Fixnum, :to_s]] }
+        output = { cvasgn: [:@@name, [String, :+, fixnum_or_integer, :to_s]] }
         expect(input).to be_parsed_as output
       end
     end
@@ -29,7 +29,7 @@ describe CodeBreaker::Parser do
     context 'for a global variable assignment' do
       it 'returns a Hash with key :cvasgn' do
         input  = "$name = 'John Doe' + 24.to_s"
-        output = { gvasgn: [:'$name', [String, :+, Fixnum, :to_s]] }
+        output = { gvasgn: [:'$name', [String, :+, fixnum_or_integer, :to_s]] }
         expect(input).to be_parsed_as output
       end
     end
@@ -45,13 +45,13 @@ describe CodeBreaker::Parser do
     context 'for a multiple variable assignment' do
       it 'returns an assignment hash if RHS is an Array' do
         input  = "x, y = ['holy', 108]"
-        output = { masgn: { [:x, :y] => [String, Fixnum] } }
+        output = { masgn: { [:x, :y] => [String, fixnum_or_integer] } }
         expect(input).to be_parsed_as output
       end
 
       it 'returns an assignment hash if RHS is a variable list' do
         input  = "x, y = 'holy', 108"
-        output = { masgn: { [:x, :y] => [String, Fixnum] } }
+        output = { masgn: { [:x, :y] => [String, fixnum_or_integer] } }
         expect(input).to be_parsed_as output
       end
 
@@ -65,7 +65,7 @@ describe CodeBreaker::Parser do
     context 'for an operation assignment' do
       it 'returns a Hash with key :op_asgn' do
         input  = 'a += 1'
-        output = { op_asgn: [{ lvasgn: [:a] }, :+, Fixnum] }
+        output = { op_asgn: [{ lvasgn: [:a] }, :+, fixnum_or_integer] }
         expect(input).to be_parsed_as output
       end
     end

--- a/spec/code_breaker/parser/data_types_spec.rb
+++ b/spec/code_breaker/parser/data_types_spec.rb
@@ -10,12 +10,18 @@ describe CodeBreaker::Parser do
         '"string"'  => String,
         ':symbol'   => Symbol,
         '3.5'       => Float,
-        '1'         => Fixnum,
-        '/^R+uby$/' => Regexp,
-        '4_611_686_018_427_387_904' => Bignum
+        '/^R+uby$/' => Regexp
       }.each do |input, output|
         it "returns #{output} for #{input}" do
           expect(input).to be_parsed_as output
+        end
+
+        it 'returns Fixnum or Integer for 1' do
+          expect(1).to be_parsed_as fixnum_or_integer
+        end
+
+        it 'returns Bignum or Integer for 4_611_686_018_427_387_904' do
+          expect(4_611_686_018_427_387_904).to be_parsed_as bignum_or_integer
         end
       end
     end
@@ -23,7 +29,7 @@ describe CodeBreaker::Parser do
     context 'for a root node representing an Array' do
       it 'returns a Hash with key :array and an Array of items' do
         input  = "[1, 'apple', :a, Day]"
-        output = { array: [Fixnum, String, Symbol, { const: :Day }] }
+        output = { array: [fixnum_or_integer, String, Symbol, { const: :Day }] }
         expect(input).to be_parsed_as output
       end
     end
@@ -53,7 +59,7 @@ describe CodeBreaker::Parser do
     context 'for a root node representing an interpolated string' do
       it 'returns a Hash with key :dstr and an Array of interpolation values' do
         input  = '"#{1 + 2} interpolated string #{\'here\'}"'
-        output = { dstr: [[Fixnum, :+, Fixnum], String, [String]] }
+        output = { dstr: [[fixnum_or_integer, :+, fixnum_or_integer], String, [String]] }
         expect(input).to be_parsed_as output
       end
     end

--- a/spec/code_breaker/parser/keywords_spec.rb
+++ b/spec/code_breaker/parser/keywords_spec.rb
@@ -6,7 +6,7 @@ describe CodeBreaker::Parser do
       context "for a root node representing an #{connector} connection" do
         it 'returns a Hash with key :or and the connected children' do
           input  = "1.to_s #{connector} 5.5"
-          output = { or: [[Fixnum, :to_s], Float] }
+          output = { or: [[fixnum_or_integer, :to_s], Float] }
           expect(input).to be_parsed_as output
         end
       end
@@ -16,7 +16,7 @@ describe CodeBreaker::Parser do
       context "for a root node representing an #{connector} connection" do
         it 'returns a Hash with key :and and the connected children' do
           input  = "1.to_s #{connector} 5.5"
-          output = { and: [[Fixnum, :to_s], Float] }
+          output = { and: [[fixnum_or_integer, :to_s], Float] }
           expect(input).to be_parsed_as output
         end
       end
@@ -26,7 +26,7 @@ describe CodeBreaker::Parser do
       context 'with only an if clause' do
         it 'returns a Hash with key :if and the if clause body' do
           input  = "'2'.to_i if 2 == '2'"
-          output = { if: [Fixnum, :==, String], then: [String, :to_i] }
+          output = { if: [fixnum_or_integer, :==, String], then: [String, :to_i] }
           expect(input).to be_parsed_as output
         end
       end
@@ -34,7 +34,7 @@ describe CodeBreaker::Parser do
       context 'with an if/then clause' do
         it 'returns a Hash with key :if and the if clause body' do
           input  = "if 2 == '2' then '2'.to_i end"
-          output = { if: [Fixnum, :==, String], then: [String, :to_i] }
+          output = { if: [fixnum_or_integer, :==, String], then: [String, :to_i] }
           expect(input).to be_parsed_as output
         end
       end
@@ -43,7 +43,7 @@ describe CodeBreaker::Parser do
         it 'returns a Hash with key :if and the if clause body' do
           input  = "if 2 == '2' then '2'.to_i else Rational(2, 3).to_s end"
           output = {
-            if: [Fixnum, :==, String],
+            if: [fixnum_or_integer, :==, String],
             then: [String, :to_i],
             else: [Rational, :to_s]
           }
@@ -56,7 +56,7 @@ describe CodeBreaker::Parser do
         it 'returns a Hash with key :if and the if clause body' do
           input  = "if 2 == '2' then '2'.to_i elsif true then Object.new end"
           output = {
-            if: [Fixnum, :==, String],
+            if: [fixnum_or_integer, :==, String],
             then: [String, :to_i],
             else: {
               if: TrueClass,
@@ -124,7 +124,7 @@ describe CodeBreaker::Parser do
             module: [
               { const: :Breakable },
               [
-                { casgn: [:CONST, Fixnum] },
+                { casgn: [:CONST, fixnum_or_integer] },
                 { casgn: [:OTHER_CONST, [String, :freeze]] }
               ]
             ]
@@ -138,13 +138,13 @@ describe CodeBreaker::Parser do
     context 'for a root node representing a return' do
       it 'returns a Hash with key :return and the returned value' do
         input  = 'return 3'
-        output = { return: Fixnum }
+        output = { return: fixnum_or_integer }
         expect(input).to be_parsed_as output
       end
 
       it 'returns a Hash with key :return and the returned values as Array' do
         input  = 'return 3 + 2'
-        output = { return: [Fixnum, :+, Fixnum] }
+        output = { return: [fixnum_or_integer, :+, fixnum_or_integer] }
         expect(input).to be_parsed_as output
       end
     end
@@ -152,7 +152,7 @@ describe CodeBreaker::Parser do
     context 'for a root node representing a yield' do
       it 'returns a Hash with key :yield and the types of given arguments' do
         input  = "yield(3, 'beer')"
-        output = { yield: [Fixnum, String] }
+        output = { yield: [fixnum_or_integer, String] }
         expect(input).to be_parsed_as output
       end
 
@@ -184,7 +184,7 @@ describe CodeBreaker::Parser do
         input  = "for i in 1..5 do\nputs i\nend"
         output = {
           for: { lvasgn: [:i] },
-          in: { irange: [Fixnum, Fixnum] },
+          in: { irange: [fixnum_or_integer, fixnum_or_integer] },
           do: [:puts, { lvar: :i }]
         }
 
@@ -247,9 +247,9 @@ describe CodeBreaker::Parser do
             {
               case: [
                 { lvar: :state },
-                { when: Symbol, then: [Fixnum, :to_s] },
-                { when: Symbol, then: [Fixnum, :to_s] },
-                { else: Fixnum }
+                { when: Symbol, then: [fixnum_or_integer, :to_s] },
+                { when: Symbol, then: [fixnum_or_integer, :to_s] },
+                { else: fixnum_or_integer }
               ]
             }
           ]
@@ -266,8 +266,8 @@ describe CodeBreaker::Parser do
             {
               case: [
                 { lvar: :state },
-                { when: Symbol, then: [Fixnum, :to_s] },
-                { when: Symbol, then: [Fixnum, :to_s] }
+                { when: Symbol, then: [fixnum_or_integer, :to_s] },
+                { when: Symbol, then: [fixnum_or_integer, :to_s] }
               ]
             }
           ]

--- a/spec/code_breaker/parser/language_elements_spec.rb
+++ b/spec/code_breaker/parser/language_elements_spec.rb
@@ -7,7 +7,7 @@ describe CodeBreaker::Parser do
         input  = '5.times { |n| n.to_s }'
         output = {
           block: [
-            [Fixnum, :times],
+            [fixnum_or_integer, :times],
             { args: [{ arg: :n }] },
             [{ lvar: :n }, :to_s]
           ]
@@ -22,7 +22,7 @@ describe CodeBreaker::Parser do
         input  = '[1, 2].reduce(0) { |sum, n| sum += n }'
         output = {
           block: [
-            [{ array: [Fixnum, Fixnum] }, :reduce, Fixnum],
+            [{ array: [fixnum_or_integer, fixnum_or_integer] }, :reduce, fixnum_or_integer],
             { args: [{ arg: :sum }, { arg: :n }] },
             { op_asgn: [{ lvasgn: [:sum] }, :+, { lvar: :n }] }
           ]
@@ -35,7 +35,7 @@ describe CodeBreaker::Parser do
     context 'for a root node representing a block pass' do
       it 'returns an array with a Hash with the :block_pass key' do
         input  = '[1, 2].map &:to_s'
-        output = [{ array: [Fixnum, Fixnum] }, :map, { block_pass: :to_s }]
+        output = [{ array: [fixnum_or_integer, fixnum_or_integer] }, :map, { block_pass: :to_s }]
         expect(input).to be_parsed_as output
       end
     end
@@ -79,7 +79,7 @@ describe CodeBreaker::Parser do
             {
               args: [
                 { arg: :name },
-                { optarg: [:options, { hash: [{ Symbol => Fixnum }] }] }
+                { optarg: [:options, { hash: [{ Symbol => fixnum_or_integer }] }] }
               ]
             },
             String
@@ -134,7 +134,7 @@ describe CodeBreaker::Parser do
       context 'for a root node representing a splat operator' do
         it 'returns a Hash with key :splat and the splat values' do
           input  = 'puts(*[1,2])'
-          output = [:puts, { splat: { array: [Fixnum, Fixnum] } }]
+          output = [:puts, { splat: { array: [fixnum_or_integer, fixnum_or_integer] } }]
           expect(input).to be_parsed_as output
         end
       end

--- a/spec/code_breaker/parser/ranges_spec.rb
+++ b/spec/code_breaker/parser/ranges_spec.rb
@@ -13,7 +13,7 @@ describe CodeBreaker::Parser do
     context 'for a root node representing an exclusive range' do
       it 'returns a Hash with key :erange and the bounding types' do
         input  = '1.2...4'
-        output = { erange: [Float, Fixnum] }
+        output = { erange: [Float, fixnum_or_integer] }
         expect(input).to be_parsed_as output
       end
     end

--- a/spec/code_breaker/parser/wrappers_spec.rb
+++ b/spec/code_breaker/parser/wrappers_spec.rb
@@ -14,14 +14,14 @@ describe CodeBreaker::Parser do
     context 'for a simple method call on Objects' do
       it 'returns an Array with the classes and methods' do
         input  = '1 + 3.5 * Rational(2,3) - Complex(1, 2)'
-        output = [Fixnum, :+, Float, :*, Rational, :-, Complex]
+        output = [fixnum_or_integer, :+, Float, :*, Rational, :-, Complex]
         expect(input).to be_parsed_as output
       end
 
       describe 'with braces' do
         it 'returns a nested Array with the classes and methods' do
           input  = '((1 + 3.5) - Rational(2,3)) * Complex(1, 2)'
-          output = [[[Fixnum, :+, Float], :-, Rational], :*, Complex]
+          output = [[[fixnum_or_integer, :+, Float], :-, Rational], :*, Complex]
           expect(input).to be_parsed_as output
         end
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,3 +2,7 @@ $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'code_breaker'
 
 Dir[File.dirname(__FILE__) + '/support/**/*.rb'].each { |f| require f }
+
+RSpec.configure do |config|
+  config.include VersionHelpers
+end

--- a/spec/support/helpers/version_helpers.rb
+++ b/spec/support/helpers/version_helpers.rb
@@ -1,0 +1,9 @@
+module VersionHelpers
+  def fixnum_or_integer
+    RUBY_VERSION < '2.4.0' ? Fixnum : Integer
+  end
+
+  def bignum_or_integer
+    RUBY_VERSION < '2.4.0' ? Bignum : Integer
+  end
+end


### PR DESCRIPTION
This fixes deprecation warnings because of unifying Fixnum and Bignum into Integer in v.2.4.0.
See https://www.ruby-lang.org/en/news/2016/12/25/ruby-2-4-0-released